### PR TITLE
워크플로우 추가 및 reverse_proxy 비정상 종료 해결

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 .github @scarf005
 
-/frontend/ @exciting-transcendence/team
-/backend/ @exciting-transcendence/team-1
+/frontend/ @exciting-transcendence/front
+/backend/ @exciting-transcendence/back

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+프론트엔드:
+  - frontend/app/**/*
+
+백엔드:
+  - backend/app/**/*
+
+ci:
+  [
+    ".github/**/*",
+    "**/*.yml",
+    "**/*.yaml",
+    "**/*Dockerfile*",
+    "**/*Dockerfile*.*",
+    "**/*compose*.*.yml",
+    "**/*compose*.yml",
+  ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-
 ## 개요
 
 <!--
 이 PR이 해결한 이슈를 아래처럼 추가해주세요.
+resolved와 같은 키워드를 **반드시** 포함해야 이 PR이 머지될 때 연관된 이슈도 같이 닫힙니다.
 참고: https://bumkeyy.gitbook.io/bumkeyy-code/project-management/pull-request
 
 - closed #15

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,14 @@
+name: label pull requests
+on:
+  pull_request_target:
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/project_board.yml
+++ b/.github/workflows/project_board.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, reopened, closed, assigned]
 
   pull_request_target:
-    types: [opened, reopened, review_requested, closed]
+    types: [opened, reopened, closed] # review_requested
 
 env:
   PROJECT_ID: 1

--- a/.github/workflows/project_board.yml
+++ b/.github/workflows/project_board.yml
@@ -3,7 +3,7 @@ on:
   issues:
     types: [opened, reopened, closed, assigned]
 
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, review_requested, closed]
 
 env:
@@ -46,7 +46,7 @@ jobs:
           echo "::set-output name=moveto::$TO"
           echo "::set-output name=node_id::$NODE"
       - name: move card to ${{ steps.figure.outputs.moveto }}
-        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
           gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           organization: ${{ github.repository_owner }}

--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,3 +1,5 @@
 FROM  nginx:stable-alpine
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+ENTRYPOINT [ "nginx", "-g", "daemon off;" ]


### PR DESCRIPTION
#개요

## `.github/CODEOWNERS`
팀명 `front`, `back`으로 변경 

## `.github/dependabot.yml`
매일 자동으로 npm 의존성 업데이트

## `.github/labeler.yml` `.github/workflows/label.yml`
릴리즈 시 자동 라벨링 추가

## `reverse_proxy/Dockerfile`
데몬에서 포그라운드 모드로 변경

## `.github/workflows/project_board.yml`
포크에서 PR시 워크플로우 비밀이 공유되지 않던 문제 해?결

## `reverse_proxy/Dockerfile`
`reverse_proxy` 서비스가 정상적으로 종료되게 데몬에서 포그라운드 서비스로 변경