### PR TITLE
자바스크립트 객체 key/value값 잘못 사용한것 수정

### DIFF
--- a/backend/app/src/configs/chat-event.constants.ts
+++ b/backend/app/src/configs/chat-event.constants.ts
@@ -1,10 +1,10 @@
 export const chatEvent = {
-  JOIN,
-  LEAVE,
-  CREATE,
-  SEND,
-  RECEIVE,
-  NOTICE,
-  ADD_ADMIN,
-  REMOVE_ADMIN,
+  JOIN: 'JOIN',
+  LEAVE: 'LEAVE',
+  CREATE: 'CREATE',
+  SEND: 'SEND',
+  RECEIVE: 'RECEIVE',
+  NOTICE: 'NOTICE',
+  ADD_ADMIN: 'ADD_ADMIN',
+  REMOVE_ADMIN: 'REMOVE_ADMIN',
 } as const


### PR DESCRIPTION

```ts
export const chatEvent = {
  JOIN: 'JOIN',
  LEAVE: 'LEAVE',
  CREATE: 'CREATE',
  SEND: 'SEND',
  RECEIVE: 'RECEIVE',
  NOTICE: 'NOTICE',
  ADD_ADMIN: 'ADD_ADMIN',
  REMOVE_ADMIN: 'REMOVE_ADMIN',
} as const
```
이렇게 쓰는 것이 맞았네요 죄송합니다...