### PR TITLE
dotenv를 서브모듈로 추가, 기존 바인드 마운트 방식 재추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+dotenv/.env

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+# .env (dotenv is managed by private submodule)
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dotenv"]
+	path = dotenv
+	url = git@github.com:exciting-transcendence/dotenv.git

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 즐~~~~~거운 웹서비스
 
-`.env.sample` 참고해서 같은 위치에 `.env`파일 작성해주세요
+## 설치
+### 환경 변수
+- 환경 변수는 `transcendence/dotenv` 서브모듈에 있습니다
+```bash
+git config -g submodule.recurse true
+git pull
+```
+을 하여 서브모듈을 업데이트하세요
 
 개발모드:
 `./dc.sh dev up --build`
@@ -12,8 +19,7 @@
 
 dc.sh에서 npm install이 되어있지 않을 때 자동으로 install하는 로직이 들어있지만, 잘 작동하지 않는 경우 install.sh를 실행해주세요
 
-## docs
-
+## 문서
 ### swagger
 
 http://localhost:3000/api

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 - 환경 변수는 `transcendence/dotenv` 서브모듈에 있습니다
 ```bash
 git config -g submodule.recurse true
-git pull
+git submodule update --init --recursive
 ```
-을 하여 서브모듈을 업데이트하세요
+을 하여 서브모듈을 초기화하세요
 
 개발모드:
 `./dc.sh dev up --build`

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 즐~~~~~거운 웹서비스
 
 ## 설치
+
 ### 환경 변수
+
 - 환경 변수는 `transcendence/dotenv` 서브모듈에 있습니다
+
 ```bash
 git config -g submodule.recurse true
 git submodule update --init --recursive
 ```
+
 을 하여 서브모듈을 초기화하세요
 
 개발모드:
@@ -17,9 +21,10 @@ git submodule update --init --recursive
 프로덕션 모드:
 `./dc.sh prod up --build`
 
-dc.sh에서 npm install이 되어있지 않을 때 자동으로 install하는 로직이 들어있지만, 잘 작동하지 않는 경우 install.sh를 실행해주세요
+dc.sh에서 npm ci이 되어있지 않을 때 자동으로 install하는 로직이 들어있지만, 잘 작동하지 않는 경우 install.sh를 실행해주세요
 
 ## 문서
+
 ### swagger
 
 http://localhost:3000/api

--- a/backend/Dockerfile.bind
+++ b/backend/Dockerfile.bind
@@ -1,0 +1,7 @@
+FROM node:lts-alpine3.15
+
+COPY avatar /srv/uploads/avatar
+
+WORKDIR /app
+
+ENTRYPOINT [ "npm", "run", "start:dev" ]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -8,6 +8,6 @@ COPY app /app
 
 WORKDIR /app
 
-RUN  npm install
+RUN  npm ci
 
 ENTRYPOINT [ "npm", "run", "start:dev" ]

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -8,6 +8,6 @@ COPY app /app
 
 WORKDIR /app
 
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 ENTRYPOINT [ "npm", "run", "start:prod" ]

--- a/backend/app/README.md
+++ b/backend/app/README.md
@@ -29,7 +29,7 @@
 ## Installation
 
 ```bash
-$ npm install
+$ npm ci
 ```
 
 ## Running the app

--- a/dc.sh
+++ b/dc.sh
@@ -1,28 +1,49 @@
 #! /bin/bash
 
+# Setup ARGV
+TYPE=$1
+shift
+ARGS=$@
+
+# Constants
 DOCKER_COMPOSE_DEV=$(dirname $0)/docker-compose.dev.yml
 DOCKER_COMPOSE_PROD=$(dirname $0)/docker-compose.prod.yml
+DOCKER_COMPOSE_BIND=$(dirname $0)/docker-compose.bind.yml
 
 BACKEND_ROOT=$(dirname $0)/backend/app
 FRONT_ROOT=$(dirname $0)/frontend/app
 
-function print_usage_and_exit() {
-	echo "Usage: $0 <dev|prod> <command> <...args>"
-	exit 1
+print_usage_and_exit() {
+  echo "Usage: $0 <dev|prod> <command> <...args>"
+  exit 1
 }
 
-test $# -lt 2 && print_usage_and_exit 
+setup_dependencies() {
+  test -d $BACKEND_ROOT/node_modules || (cd $BACKEND_ROOT && npm install)
+  test -d $FRONT_ROOT/node_modules || (cd $FRONT_ROOT && npm install)
+  npm install
+}
 
-if [ $1 = "dev" ]; then	
-	TARGET_DOCKER_COMPOSE=$DOCKER_COMPOSE_DEV
-	test -d $BACKEND_ROOT/node_modules || (cd $BACKEND_ROOT && npm install)
-	test -d $FRONT_ROOT/node_modules || (cd $FRONT_ROOT && npm install)
-elif [ $1 = "prod" ]; then
-	TARGET_DOCKER_COMPOSE=$DOCKER_COMPOSE_PROD
-else
-	print_usage_and_exit
-fi
+run_compose() {
+	local file=$1
+	exec docker-compose -f $file $ARGS
+}
+
+case $TYPE in
+  dev)
+    setup_dependencies
+    run_compose $DOCKER_COMPOSE_DEV
+    ;;
+	bind)
+		run_compose $DOCKER_COMPOSE_BIND
+		;;
+  prod)
+    run_compose $DOCKER_COMPOSE_PROD
+    ;;
+  *)
+    print_usage_and_exit
+    ;;
+esac
 
 shift
 
-exec docker-compose -f $TARGET_DOCKER_COMPOSE $@

--- a/dc.sh
+++ b/dc.sh
@@ -19,14 +19,14 @@ print_usage_and_exit() {
 }
 
 setup_dependencies() {
-  test -d $BACKEND_ROOT/node_modules || (cd $BACKEND_ROOT && npm install)
-  test -d $FRONT_ROOT/node_modules || (cd $FRONT_ROOT && npm install)
-  npm install
+  test -d $BACKEND_ROOT/node_modules || (cd $BACKEND_ROOT && npm ci)
+  test -d $FRONT_ROOT/node_modules || (cd $FRONT_ROOT && npm ci)
+  npm ci
 }
 
 run_compose() {
-	local file=$1
-	exec docker-compose -f $file $ARGS
+  local file=$1
+  exec docker-compose -f $file $ARGS
 }
 
 case $TYPE in
@@ -34,9 +34,9 @@ case $TYPE in
     setup_dependencies
     run_compose $DOCKER_COMPOSE_DEV
     ;;
-	bind)
-		run_compose $DOCKER_COMPOSE_BIND
-		;;
+  bind)
+    run_compose $DOCKER_COMPOSE_BIND
+    ;;
   prod)
     run_compose $DOCKER_COMPOSE_PROD
     ;;
@@ -46,4 +46,3 @@ case $TYPE in
 esac
 
 shift
-

--- a/docker-compose.bind.yml
+++ b/docker-compose.bind.yml
@@ -1,0 +1,88 @@
+version: '3.3'
+
+services:
+  frontend:
+    build:
+      context: frontend
+      dockerfile: Dockerfile.bind
+    restart: always
+    volumes:
+      - "./frontend/app:/app"
+    expose:
+      - 3000
+    networks:
+      - internal
+
+  storybook:
+    build:
+      context: frontend
+      dockerfile: Dockerfile.dev.storybook
+    restart: always
+    volumes:
+      - "./frontend/app:/app"
+    expose:
+      - 6006
+    networks:
+      - internal
+    logging:
+      driver: none
+
+  reverse_proxy:
+    build: reverse_proxy
+    restart: always
+    ports:
+      - "3000:3000"
+    networks:
+      - internal
+    depends_on:
+      - frontend
+      - backend
+
+  backend:
+    build:
+      context: backend
+      dockerfile: Dockerfile.bind
+
+    restart: always
+    volumes:
+      - "./backend/app:/app"
+      - "avatar:/srv/uploads/avatar"
+
+    env_file: .env
+
+    expose:
+      - 3000
+
+    depends_on:
+      - database
+
+    networks:
+      - internal
+
+  database:
+    build:
+      context: db
+      dockerfile: Dockerfile
+
+    restart: always
+
+    expose:
+      - 5432
+
+    volumes:
+      - "database:/var/lib/postgresql/data"
+
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_PASSWORD: ${DB_PASSWORD}
+
+    networks:
+      - internal
+
+volumes:
+  database:
+  avatar:
+
+
+networks:
+  internal:

--- a/frontend/Dockerfile.bind
+++ b/frontend/Dockerfile.bind
@@ -1,0 +1,5 @@
+FROM node:lts-alpine3.15
+
+WORKDIR /app
+
+ENTRYPOINT [ "npm", "run", "start" ]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -4,6 +4,6 @@ COPY app /app
 
 WORKDIR /app
 
-RUN  npm install
+RUN  npm ci
 
 ENTRYPOINT [ "npm", "run", "start" ]

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -7,6 +7,6 @@ COPY nginx.conf /etc/nginx/http.d/app.conf
 COPY app /app
 WORKDIR /app
 
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 ENTRYPOINT [ "nginx",  "-g", "daemon off;" ]


### PR DESCRIPTION
## 개요
- dotenv를 서브모듈로 관리
- 기존 `./dc.sh dev` 명령을 `./dc.sh bind`로 재추

## 내용
### 서브모듈이란
- https://git-scm.com/book/ko/v2/Git-도구-서브모듈
- https://ohgyun.com/711

머지 이후 `.env`를 사용하기 위해서는 [README.md](https://github.com/exciting-transcendence/transcendence/blob/develop/README.md) 참고

### 기존 컴포즈 옵션 복구
- 리눅스, WSL에서는 `app/` 전체를 바인드 마운트해서 생기는 지연보다 `./dc.sh dev build`을 실행하고 `npm install`을 하는 시간이 훨씬 큼
- `./dc.sh bind ...` 명령으로 실행

## 그밖에
컴포즈 파일을 2개로 합치기?