### PR TITLE
웹소켓에서 class-validator 적용

### DIFF
--- a/backend/app/src/chat/chat.gateway.ts
+++ b/backend/app/src/chat/chat.gateway.ts
@@ -15,8 +15,11 @@ import { ChatService } from './chat.service'
 import * as jwt from 'jsonwebtoken'
 import { jwtConstants } from 'configs/jwt-token.config'
 import { ChatRoom } from './chatroom.entity'
+import { UsePipes } from '@nestjs/common'
+import { WSValidationPipe } from 'utils/WSValidationPipe'
 
 @AsyncApiService()
+@UsePipes(new WSValidationPipe())
 @WebSocketGateway({ namespace: 'api/chat', cors: true })
 export class ChatGateway {
   constructor(private readonly chatService: ChatService) {}

--- a/backend/app/src/chat/chat.gateway.ts
+++ b/backend/app/src/chat/chat.gateway.ts
@@ -10,6 +10,8 @@ import { Server, Socket } from 'socket.io'
 import { chatEvent } from 'configs/chat-event.constants'
 import { ChatMessageDto } from 'dto/chatMessage.dto'
 import { UserInRoomDto } from 'dto/userInRoom.dto'
+import { ChatCreateRoomDto } from 'dto/chatCreateRoom.dto'
+import { ChatJoinRoomDto } from 'dto/chatJoinRoom.dto'
 import { ChatRoomDto } from 'dto/chatRoom.dto'
 import { ChatService } from './chat.service'
 import * as jwt from 'jsonwebtoken'
@@ -107,17 +109,17 @@ export class ChatGateway {
     channel: chatEvent.JOIN,
     summary: '채팅방에 참가',
     description: 'user가 채팅방에 새로 입장. 알림메시지를 모든 구성원에게 전송',
-    message: { name: 'ChatRoomDto', payload: { type: ChatRoomDto } },
+    message: { name: 'ChatJoinRoomDto', payload: { type: ChatJoinRoomDto } },
   })
   async onJoinRoom(
     @ConnectedSocket() client: Socket,
-    @MessageBody() room: ChatRoomDto,
+    @MessageBody() room: ChatJoinRoomDto,
   ) {
     try {
       await this.chatService.addUserToRoom(
         client.data.uid,
         room.roomId,
-        room.roomPassword,
+        room.password,
       )
     } catch (error) {
       return error
@@ -168,20 +170,23 @@ export class ChatGateway {
   @AsyncApiPub({
     channel: chatEvent.CREATE,
     summary: '새로운 채팅방 생성',
-    message: { name: 'ChatRoomDto', payload: { type: ChatRoomDto } },
+    message: {
+      name: 'ChatCreateRoomDto',
+      payload: { type: ChatCreateRoomDto },
+    },
   })
   @SubscribeMessage(chatEvent.CREATE)
   async onCreateRoom(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: ChatRoomDto,
+    @MessageBody() data: ChatCreateRoomDto,
   ) {
     let newRoom: ChatRoom
     try {
       newRoom = await this.chatService.createChatroom(
         client.data.uid,
-        data.roomName,
-        data.roomType,
-        data.roomPassword,
+        data.title,
+        data.type,
+        data.password,
       )
     } catch (error) {
       return error

--- a/backend/app/src/dto/chatCreateRoom.dto.ts
+++ b/backend/app/src/dto/chatCreateRoom.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { RoomType } from 'chat/roomtype.enum'
+import { IsEnum, IsString, ValidateIf } from 'class-validator'
+
+export class ChatCreateRoomDto {
+  @ApiProperty({
+    description: '새 채팅방 이름',
+    examples: ['test_title'],
+  })
+  @IsString()
+  title: string
+
+  @ApiProperty({
+    description: 'PROTECTED는 암호 필요, PRIVATE은 초대받은 사용자만 입장 가능',
+    enum: RoomType,
+  })
+  @IsEnum(RoomType)
+  type: RoomType
+
+  @ApiProperty({ description: 'bcrypted string', required: false })
+  @IsString()
+  @ValidateIf((o) => o.roomType === RoomType.PROTECTED)
+  password?: string
+}

--- a/backend/app/src/dto/chatJoinRoom.dto.ts
+++ b/backend/app/src/dto/chatJoinRoom.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { IsNumber, IsString } from 'class-validator'
+
+export class ChatJoinRoomDto {
+  @ApiProperty({
+    description: '채팅방 고유 번호',
+  })
+  @IsNumber()
+  roomId: number
+
+  @ApiProperty({ description: 'bcrypted string', required: false })
+  @IsString()
+  password?: string
+}

--- a/backend/app/src/utils/WSValidationPipe.ts
+++ b/backend/app/src/utils/WSValidationPipe.ts
@@ -1,0 +1,16 @@
+import { Injectable, ValidationPipe } from '@nestjs/common'
+import { WsException } from '@nestjs/websockets'
+
+@Injectable()
+export class WSValidationPipe extends ValidationPipe {
+  createExceptionFactory() {
+    return (validationErrors = []) => {
+      if (this.isDetailedOutputDisabled) {
+        return new WsException('Bad Request')
+      }
+      const errors = this.flattenValidationErrors(validationErrors)
+
+      return new WsException(errors)
+    }
+  }
+}

--- a/frontend/app/src/view/ChatRoomList.tsx
+++ b/frontend/app/src/view/ChatRoomList.tsx
@@ -18,7 +18,7 @@ export const ChatRoomList = (prop: {
   setShowChat: any
 }) => {
   const joinRoom = (room: number) => {
-    prop.socket.emit('JOIN', { roomId: room} )
+    prop.socket.emit('JOIN', { roomId: room })
     prop.setShowChat({ bool: true, roomId: room })
   }
   return (

--- a/frontend/app/src/view/CreateRoomModal.tsx
+++ b/frontend/app/src/view/CreateRoomModal.tsx
@@ -82,7 +82,7 @@ export const BasicModal = (prop: {
   const createRoom = () => {
     const roomName = input.current?.value
     console.log(roomName)
-    prop.socket.emit('CREATE', roomName)
+    prop.socket.emit('CREATE', { title: roomName, type: 'PUBLIC' })
     handleClose()
   }
   return (


### PR DESCRIPTION
## 개요
게이트웨이에서 class validator를 정상적으로 사용하기 위해 custom validation pipe 적용
채팅방 생성, 참여를 위한 DTO 수정
- closed #126

## 
검증 실패시 클라이언트측에서 사유를 알아야 한다면 `socket.on('exception', (err) => {})`로 확인할 수 있습니다.
