### PR TITLE
feat: 관전 기능 구현

### DIFF
--- a/backend/app/src/pong/match.gateway.ts
+++ b/backend/app/src/pong/match.gateway.ts
@@ -75,11 +75,11 @@ export class MatchGateWay implements OnGatewayDisconnect, OnGatewayConnection {
 
   @SubscribeMessage('spectator')
   handleSpectator(
-    @MessageBody() message: { gameId: number },
+    @MessageBody() message: { uid: number },
     @ConnectedSocket() client: UserSocket,
   ) {
-    const manager = this.pongService.getGameByGameId(Number(message.gameId))
-    manager?.addSpectator(client)
+    const game = this.pongService.getGameByUser(Number(message.uid))
+    game?.manager.addSpectator(client)
   }
 
   handleDisconnect(client: UserSocket) {

--- a/backend/app/src/user/user.controller.ts
+++ b/backend/app/src/user/user.controller.ts
@@ -51,8 +51,8 @@ export class UserController {
     description: 'query string: uid',
   })
   @ApiCreatedResponse({ description: 'FindUserDto', type: FindUserDto })
-  async getUserByUid(@Param() param: FindInputDto): Promise<FindUserDto> {
-    return await this.userService.findOneByUid(param.targetUid)
+  async getUserByUid(@Param('uid') uid: number): Promise<FindUserDto> {
+    return await this.userService.findOneByUid(uid)
   }
 
   @Get()

--- a/frontend/app/src/components/profile/OtherProfile.tsx
+++ b/frontend/app/src/components/profile/OtherProfile.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import {
   ButtonGroup,
   Card,
@@ -14,7 +14,11 @@ import {
   BlockButton,
   UnblockButton,
   MessageButton,
+  JoinGameAsSpectatorButton,
 } from './userActions'
+
+import { PongSocketContext } from 'router/Main'
+import { useNavigate } from 'react-router-dom'
 
 type userStatus = 'DEFAULT' | 'BLOCKED' | 'FRIEND'
 const getStatus = (user: User, refUser: User): userStatus => {
@@ -27,7 +31,18 @@ const getStatus = (user: User, refUser: User): userStatus => {
   }
 }
 
-const Actions = ({ status }: { status: userStatus }) => {
+const Actions = ({
+  status,
+  selfUid,
+  isInGame,
+}: {
+  status: userStatus
+  selfUid: number
+  isInGame: boolean
+}) => {
+  const pongSocket = useContext(PongSocketContext)
+  const navigate = useNavigate()
+
   if (status === 'BLOCKED') {
     return <UnblockButton onClick={() => alert('pressed unblock button')} />
   }
@@ -43,6 +58,18 @@ const Actions = ({ status }: { status: userStatus }) => {
       )}
       <BlockButton onClick={() => alert('pressed block button')} />
       <MessageButton onClick={() => alert('pressed direct message button')} />
+      {isInGame ? (
+        <JoinGameAsSpectatorButton
+          onClick={() => {
+            if (pongSocket !== undefined) {
+              pongSocket.emit('spectator', {
+                uid: selfUid,
+              })
+              navigate('/game')
+            }
+          }}
+        />
+      ) : null}
     </ButtonGroup>
   )
 }
@@ -59,7 +86,11 @@ export const OtherProfile = ({ user, refUser }: Props) => {
       <Profile user={user} />
       <Typography align="center">{`status: ${status}`}</Typography>
       <Grid container justifyContent="right">
-        <Actions status={status} />
+        <Actions
+          status={status}
+          isInGame={user.status === 'GAME'}
+          selfUid={user.uid}
+        />
       </Grid>
     </>
   )

--- a/frontend/app/src/components/profile/userActions.tsx
+++ b/frontend/app/src/components/profile/userActions.tsx
@@ -6,6 +6,7 @@ import {
   LocalPostOffice,
   PersonAdd,
   PersonRemove,
+  Visibility,
 } from '@mui/icons-material'
 
 interface OnClickProps {
@@ -54,6 +55,16 @@ export const ChangeNickNameButton = ({ onClick }: OnClickProps) => {
     <IconButtonWrap
       title="Change Nickname"
       icon={<DriveFileRenameOutline />}
+      onClick={onClick}
+    />
+  )
+}
+
+export const JoinGameAsSpectatorButton = ({ onClick }: OnClickProps) => {
+  return (
+    <IconButtonWrap
+      title="join game as sepctator"
+      icon={<Visibility />}
       onClick={onClick}
     />
   )

--- a/frontend/app/src/hook/usePongSocket.ts
+++ b/frontend/app/src/hook/usePongSocket.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react'
+import { useAuthSocket } from './useAuthSocket'
+
+type PongState = 'selectMode' | 'findMatch' | 'gameInfo' | 'play' | 'gameEnd'
+
+export const usePongSocket = () => {
+  const [gameState, setGameState] = useState<PongState>('selectMode')
+  const [gameMode, setGameMode] = useState<'player' | 'spectator'>()
+  const [player, setPlayer] = useState<any>()
+  const [gameInfo, setGameInfo] = useState<any>()
+  const [winner, setWinner] = useState<any>()
+  const socket = useAuthSocket('/api/pong')
+
+  useEffect(() => {
+    if (socket === undefined) {
+      return
+    }
+
+    socket.on('gameInfo', (message) => {
+      setGameMode(message.mode)
+      setPlayer({ leftUser: message.leftUser, rightUser: message.rightUser })
+      setGameInfo(message)
+      setGameState('gameInfo')
+    })
+
+    socket.on('render', (message) => {
+      setGameInfo(message)
+      setGameState('play')
+    })
+
+    socket.on('gameEnd', (message) => {
+      setWinner(message)
+      setGameState('gameEnd')
+    })
+  })
+
+  return {
+    socket,
+    gameState,
+    setGameState,
+    gameMode,
+    player,
+    gameInfo,
+    winner,
+  }
+}

--- a/frontend/app/src/router/Main.tsx
+++ b/frontend/app/src/router/Main.tsx
@@ -7,12 +7,16 @@ import { mockUser } from 'mock/mockUser'
 import { useEffect, createContext, useState } from 'react'
 import { io, Socket } from 'socket.io-client'
 
+import { usePongSocket } from 'hook/usePongSocket'
+
 import {
   Message,
   ClientToServerEvents,
   ServerToClientEvents,
   JoinedRoom,
 } from 'data'
+
+export const PongSocketContext = createContext<Socket | undefined>(undefined)
 
 export const MainRouter = () => {
   const [socket, setSocket] = useState<Socket>()
@@ -35,16 +39,21 @@ export const MainRouter = () => {
       socket.disconnect()
     }
   }, [])
+
+  const pongData = usePongSocket()
+
   return (
     <div>
       <Nav />
-      <Routes>
-        <Route path="/" element={<></>} />
-        <Route path="/game" element={<GameView />} />
-        <Route path="/friend" element={<FriendView />} />
-        <Route path="/profile" element={<Profile user={mockUser} />} />
-        <Route path="/Chat" element={<ChatView socket={socket} />} />
-      </Routes>
+      <PongSocketContext.Provider value={pongData.socket}>
+        <Routes>
+          <Route path="/" element={<></>} />
+          <Route path="/game" element={<GameView {...pongData} />} />
+          <Route path="/friend" element={<FriendView />} />
+          <Route path="/profile" element={<Profile user={mockUser} />} />
+          <Route path="/Chat" element={<ChatView socket={socket} />} />
+        </Routes>
+      </PongSocketContext.Provider>
     </div>
   )
 }

--- a/frontend/app/src/view/Pong.tsx
+++ b/frontend/app/src/view/Pong.tsx
@@ -1,8 +1,9 @@
 import { useRef, useEffect, useState } from 'react'
 import Avatar from '@mui/material/Avatar'
-import { Stack, Typography, Box, Modal } from '@mui/material'
+import { Stack, Typography, Box, Modal, Button } from '@mui/material'
 import styled from 'styled-components'
 import { useUser } from 'hook/useUser'
+import { useAvatar } from 'hook/useAvatar'
 
 export type Rect = {
   x: number
@@ -41,6 +42,15 @@ const drawRect = (
 
 const PongUser = (props: { uid: number }) => {
   const profile = useUser(props.uid)
+  const [_avatarFile, avatar, setAvatarFile] = useAvatar(
+    '/api/avatar/default.jpg',
+  )
+
+  useEffect(() => {
+    if (profile !== undefined) {
+      setAvatarFile(profile.avatar)
+    }
+  }, [profile])
 
   if (profile === undefined) {
     return null
@@ -48,7 +58,7 @@ const PongUser = (props: { uid: number }) => {
     return (
       <Stack justifyContent="center" alignItems="center">
         <Typography>{profile.nickname}</Typography>
-        <Avatar src={profile.avatar} />
+        <Avatar src={avatar} />
         <Typography>RATING: {profile.stat.rating}</Typography>
       </Stack>
     )
@@ -101,8 +111,7 @@ const PongRightProfile = styled.div`
   grid-row: 1 / 2;
 `
 
-const Pong = (props: PongProps) => {
-  const pongCanvas = useRef<HTMLCanvasElement>(null)
+export const PongStartCounter = () => {
   const [remainTime, setRemainTime] = useState(3)
 
   useEffect(() => {
@@ -113,6 +122,42 @@ const Pong = (props: PongProps) => {
       return () => clearTimeout(timer)
     }
   }, [remainTime])
+
+  return (
+    <Modal open={remainTime > 0}>
+      <Box sx={remainTimeModalStyle}>
+        <Typography variant="h1">{remainTime}</Typography>
+      </Box>
+    </Modal>
+  )
+}
+
+export const PongResult = ({
+  uid,
+  closeHandler,
+}: {
+  uid: number
+  closeHandler: () => void
+}) => {
+  return (
+    <Modal open={true}>
+      <Box sx={remainTimeModalStyle}>
+        <Typography variant="h2">Winner is</Typography>
+        <PongUser uid={uid} />
+        <Button
+          onClick={() => {
+            closeHandler()
+          }}
+        >
+          CLOSE
+        </Button>
+      </Box>
+    </Modal>
+  )
+}
+
+const Pong = (props: PongProps) => {
+  const pongCanvas = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     const req = requestAnimationFrame(() => {
@@ -159,21 +204,6 @@ const Pong = (props: PongProps) => {
 
   return (
     <PongGrid>
-      <Modal open={remainTime > 0}>
-        <Box sx={remainTimeModalStyle}>
-          <Typography variant="h1">{remainTime}</Typography>
-        </Box>
-      </Modal>
-      <Modal open={!!props.winner}>
-        <Box sx={remainTimeModalStyle}>
-          <Typography variant="h2">Winner is</Typography>
-          {props.winner === 'left' ? (
-            <PongUser uid={props.leftUser} />
-          ) : (
-            <PongUser uid={props.rightUser} />
-          )}
-        </Box>
-      </Modal>
       <PongLeftProfile>
         <PongUser uid={props.leftUser} />
       </PongLeftProfile>

--- a/frontend/app/src/view/RegisterUser.tsx
+++ b/frontend/app/src/view/RegisterUser.tsx
@@ -145,10 +145,7 @@ export function RegisterUser(props: {
           navigate('/')
         }
       })
-      .catch(async (err) => {
-        console.log(err)
-        console.log(err.status)
-        console.log(await err.json())
+      .catch(() => {
         navigate('/')
       })
   }


### PR DESCRIPTION
## 개요

일단 친구가 게임 중일 때 friend창에서 관전자로 참여할 수 있게 구현했습니다

### 구현 디테일

pong 소켓을 main router쪽에서 useContext를 사용해서 전역적으로 관리해서
게임 탭이 아닌 위치에서도 소켓 이벤트를 받을 수 있게 구현했습니다.
추가적으로 창을 바꾸더라도 게임 상태가 유지되도록 했습니다.

코드가 좀 스파게티네요...

<!--
이 PR이 해결한 이슈를 아래처럼 추가해주세요.
resolved와 같은 키워드를 **반드시** 포함해야 이 PR이 머지될 때 연관된 이슈도 같이 닫힙니다.
참고: https://bumkeyy.gitbook.io/bumkeyy-code/project-management/pull-request

- closed #15
- resolved #16
-->

- resolved #132