### PR TITLE
fix: addBanned & deleteBanned 수정

### DIFF
--- a/backend/app/src/chat/chatroom.entity.ts
+++ b/backend/app/src/chat/chatroom.entity.ts
@@ -2,7 +2,7 @@ import {
   Column,
   Entity,
   JoinTable,
-  ManyToMany,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm'
 import { ChatUser } from './chatuser.entity'
@@ -25,7 +25,7 @@ export class ChatRoom {
   @Column('int', { array: true, default: [] })
   bannedIds: number[]
 
-  @ManyToMany(() => ChatUser, { cascade: true })
+  @OneToMany(() => ChatUser, (chatUser) => chatUser.room, { cascade: true })
   @JoinTable()
   chatUser: ChatUser[]
 }

--- a/backend/app/src/chat/chatuser.entity.ts
+++ b/backend/app/src/chat/chatuser.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm'
 import { User } from 'user/user.entity'
 import { ApiProperty } from '@nestjs/swagger'
+import { ChatRoom } from './chatroom.entity'
 
 @Entity()
 export class ChatUser {
@@ -21,6 +22,12 @@ export class ChatUser {
 
   @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
   endOfMute: Date
+
+  @ManyToOne(() => ChatRoom, (chatRoom) => chatRoom.chatUser, {
+    onDelete: 'CASCADE',
+  })
+  @ApiProperty({ description: 'room' })
+  room: ChatRoom
 
   @ManyToOne(() => User)
   @JoinColumn()


### PR DESCRIPTION
## 개요
addBanned & deleteBanned 수정
방이 삭제되도 ChatUser 가 삭제되지 않아서 해결하기 위해 entity 수정
ban 된 user는 room의 chatuser 에서 삭제되고 bannedids 에 추가
ban이 해제된 user 는 bannedids 에서 삭제
방의 유저 목록을 가져오는 api /api/chat/:uid/list 에서 유저 정보에 stat 추가

<!--
이 PR이 해결한 이슈를 아래처럼 추가해주세요.
resolved와 같은 키워드를 **반드시** 포함해야 이 PR이 머지될 때 연관된 이슈도 같이 닫힙니다.
참고: https://bumkeyy.gitbook.io/bumkeyy-code/project-management/pull-request

- closed #15
- resolved #16
-->
- resolved #218 