### PR TITLE
feat: 뮤트,언뮤트, 관리자 추가,삭제시 모든 참여자에게 CHATUSER_STATUS 이벤트 전송

### DIFF
--- a/backend/app/src/chat/chatuserEvent.enum.ts
+++ b/backend/app/src/chat/chatuserEvent.enum.ts
@@ -1,0 +1,6 @@
+export enum ChatUserEvent {
+  ADMIN_ADDED = 'ADMIN_ADDED',
+  ADMIN_REMOVED = 'ADMIN_REMOVED',
+  MUTED = 'MUTED',
+  UNMUTED = 'UNMUTED',
+}

--- a/backend/app/src/configs/chat-event.constants.ts
+++ b/backend/app/src/configs/chat-event.constants.ts
@@ -15,4 +15,5 @@ export const chatEvent = {
   UNBAN: 'UNBAN',
   MUTE: 'MUTE',
   UNMUTE: 'UNMUTE',
+  CHATUSER_STATUS: 'CHATUSER_STATUS',
 } as const

--- a/backend/app/src/dto/chatuserStatusChanged.dto.ts
+++ b/backend/app/src/dto/chatuserStatusChanged.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { ChatUserEvent } from 'chat/chatuserEvent.enum'
+import { IsNumber, IsEnum } from 'class-validator'
+
+export class ChatUserStatusChangedDto {
+  @ApiProperty({
+    description: '채팅방 고유 번호',
+  })
+  @IsNumber()
+  roomId: number
+
+  @ApiProperty({
+    description: '상태가 변한 사람의 uid',
+  })
+  @IsNumber()
+  uid: number
+
+  @ApiProperty({
+    description: '발생한 이벤트 종류',
+    enum: ChatUserEvent,
+  })
+  @IsEnum(ChatUserEvent)
+  type: ChatUserEvent
+}


### PR DESCRIPTION
## 개요
- ui 업데이트를 위해, 뮤트,언뮤트, 관리자 추가,삭제가 성공했을 때 모든 참여자에게 "CHATUSER_STATUS" 이벤트 전송
![tmp](https://user-images.githubusercontent.com/95955033/185794817-090fec5a-8754-45b7-893b-1094e923c197.png)

