### PR TITLE
feat: service 파트에서 db 관련 서버에 에러가 출력되지 않고 프론트로 던지게 에러 추가

### DIFF
--- a/backend/app/src/app.controller.ts
+++ b/backend/app/src/app.controller.ts
@@ -1,15 +1,4 @@
-import { Controller, Get, UseGuards, Req } from '@nestjs/common'
-import { JwtAfterTwoFactorUserGuard } from 'auth/jwt.strategy'
-import { UserService } from 'user/user.service'
+import { Controller } from '@nestjs/common'
 
 @Controller('/api')
-export class AppController {
-  constructor(private userService: UserService) {}
-
-  @Get()
-  @UseGuards(JwtAfterTwoFactorUserGuard)
-  async getProfile(@Req() req: any) {
-    const { uid } = req.user
-    return await this.userService.findOneByUid(uid)
-  }
-}
+export class AppController {}

--- a/backend/app/src/auth/ft/ft-oauth.service.ts
+++ b/backend/app/src/auth/ft/ft-oauth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, InternalServerErrorException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { JwtService } from '@nestjs/jwt'
@@ -17,11 +17,15 @@ export class FtOauthService {
     const ftUser = new FtUser()
 
     ftUser.uid = intraUid
-    return await this.ftOauthRepository.save(ftUser)
+    return await this.ftOauthRepository.save(ftUser).catch(() => {
+      throw new InternalServerErrorException('Error while saving ft user')
+    })
   }
 
   async save(ftUser: FtUser) {
-    return await this.ftOauthRepository.save(ftUser)
+    return await this.ftOauthRepository.save(ftUser).catch(() => {
+      throw new InternalServerErrorException('Error while saving ft user')
+    })
   }
 
   async findOne(intraUid: number) {
@@ -32,7 +36,9 @@ export class FtOauthService {
   }
 
   async remove(intraUid: number) {
-    await this.ftOauthRepository.delete({ uid: intraUid })
+    await this.ftOauthRepository.delete({ uid: intraUid }).catch(() => {
+      throw new InternalServerErrorException('Error while deleting two factor')
+    })
   }
 
   issueToken(ftOauth: FtUser): string {

--- a/backend/app/src/auth/ft/ft.controller.ts
+++ b/backend/app/src/auth/ft/ft.controller.ts
@@ -1,8 +1,15 @@
-import { Body, Get, Put, Redirect, Req } from '@nestjs/common'
-import { Controller } from '@nestjs/common'
+import {
+  Body,
+  Get,
+  Put,
+  Redirect,
+  Req,
+  Controller,
+  UseGuards,
+  NotFoundException,
+} from '@nestjs/common'
 import { UserService } from 'user/user.service'
 import { FtOauthService } from './ft-oauth.service'
-import { UseGuards } from '@nestjs/common'
 import { FtGuard } from './ft.strategy'
 import { JwtFtGuard } from './jwt-ft.strategy'
 import { RegisterUserDto } from 'dto/registerUser.dto'
@@ -85,8 +92,7 @@ export class FtController {
     const { uid } = req.user
     const user = await this.userService.create(body)
     const ftUser = await this.ftOauthService.findOne(uid)
-
-    ftUser.user = user
+    if (!ftUser) throw new NotFoundException('FtUser not found')
     await this.ftOauthService.save(ftUser)
 
     return { access_token: this.userService.issueToken(user, !user.twoFactor) }

--- a/backend/app/src/auth/two-factor.service.ts
+++ b/backend/app/src/auth/two-factor.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, ConflictException } from '@nestjs/common'
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { User } from 'user/user.entity'
@@ -22,13 +27,18 @@ export class TwoFactorService {
     }
 
     const user = await this.userRepository.findOneBy({ uid })
+    if (!user) throw new NotFoundException('User not found')
     user.twoFactor = true
     const twoFactor = new TwoFactor()
     twoFactor.user = user
     twoFactor.secret = authenticator.generateSecret()
 
-    await this.userRepository.save(user)
-    await this.twoFactorRepository.save(twoFactor)
+    await this.userRepository.save(user).catch(() => {
+      throw new InternalServerErrorException('Error while saving user')
+    })
+    await this.twoFactorRepository.save(twoFactor).catch(() => {
+      throw new InternalServerErrorException('Error while saving two factor')
+    })
 
     return authenticator.keyuri(
       user.nickname,
@@ -43,16 +53,22 @@ export class TwoFactorService {
     }
 
     const user = await this.userRepository.findOneBy({ uid })
+    if (!user) throw new NotFoundException('User not found')
     user.twoFactor = false
 
-    await this.twoFactorRepository.delete({ user: { uid } })
-    await this.userRepository.save(user)
+    await this.twoFactorRepository.delete({ user: { uid } }).catch(() => {
+      throw new InternalServerErrorException('Error while deleting two factor')
+    })
+    await this.userRepository.save(user).catch(() => {
+      throw new InternalServerErrorException('Error while saving user')
+    })
   }
 
   async verify(uid: number, token: string): Promise<boolean> {
     const twoFactor = await this.twoFactorRepository.findOneBy({
       user: { uid },
     })
+    if (!twoFactor) throw new NotFoundException('Two factor not found')
 
     return authenticator.check(token, twoFactor.secret)
   }

--- a/backend/app/src/pong/match.service.ts
+++ b/backend/app/src/pong/match.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, InternalServerErrorException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { Socket } from 'socket.io'
@@ -127,6 +127,8 @@ export class MatchService {
     const newMatch = new Match()
     newMatch.winner = winner
     newMatch.loser = loser
-    return this.matchRepository.save(newMatch)
+    return this.matchRepository.save(newMatch).catch(() => {
+      throw new InternalServerErrorException('database error')
+    })
   }
 }


### PR DESCRIPTION
## 개요
feat: service 파트에서 db 관련 서버에 에러가 출력되지 않고 프론트로 던지게 에러 추가
gateway 부분도 try... catch를 꼼꼼히 추가해야한다.

<!--
이 PR이 해결한 이슈를 아래처럼 추가해주세요.
resolved와 같은 키워드를 **반드시** 포함해야 이 PR이 머지될 때 연관된 이슈도 같이 닫힙니다.
참고: https://bumkeyy.gitbook.io/bumkeyy-code/project-management/pull-request

- closed #15
- resolved #16
-->
